### PR TITLE
Feat: 회원가입 기능 구현

### DIFF
--- a/src/main/java/com/mission/intern/application/member/MemberService.java
+++ b/src/main/java/com/mission/intern/application/member/MemberService.java
@@ -1,0 +1,38 @@
+package com.mission.intern.application.member;
+
+import com.mission.intern.domain.member.entity.MemberRole;
+import com.mission.intern.domain.member.entity.Role;
+import com.mission.intern.domain.member.repository.MemberRepository;
+import com.mission.intern.domain.member.entity.Member;
+import com.mission.intern.domain.member.repository.RoleRepository;
+import com.mission.intern.domain.member.vo.RoleType;
+import com.mission.intern.presentation.member.dto.request.RegisterRequest;
+import com.mission.intern.presentation.member.dto.response.RegisteredMemberInfo;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class MemberService {
+
+    private final MemberRepository memberRepository;
+    private final RoleRepository roleRepository;
+
+    @Transactional
+    public RegisteredMemberInfo register(RegisterRequest request) {
+        Member member = memberRepository.save(request.of());
+        Role role = getRole(request.role());
+        MemberRole memberRole = new MemberRole(role);
+
+        member.setRole(memberRole);
+
+        return RegisteredMemberInfo.from(member);
+    }
+
+    private Role getRole(RoleType roleType) {
+        return roleRepository.findByRoleType(roleType)
+                .orElseThrow(() -> new IllegalArgumentException("해당 권한은 찾을 수 없습니다."));
+    }
+
+}

--- a/src/main/java/com/mission/intern/domain/member/entity/Member.java
+++ b/src/main/java/com/mission/intern/domain/member/entity/Member.java
@@ -1,0 +1,27 @@
+package com.mission.intern.domain.member.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.HashSet;
+import java.util.Set;
+
+@Getter
+@Entity(name = "members")
+@NoArgsConstructor
+@AllArgsConstructor
+public class Member {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long memberId;
+
+    @OneToMany(mappedBy = "member", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
+    private Set<Role> authorities = new HashSet<>();
+
+    private String username;
+    private String nickname;
+    private String password;
+}

--- a/src/main/java/com/mission/intern/domain/member/entity/Member.java
+++ b/src/main/java/com/mission/intern/domain/member/entity/Member.java
@@ -1,17 +1,18 @@
 package com.mission.intern.domain.member.entity;
 
+import com.mission.intern.domain.member.vo.RoleType;
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.util.HashSet;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 @Getter
 @Entity(name = "members")
 @NoArgsConstructor
-@AllArgsConstructor
 public class Member {
 
     @Id
@@ -19,9 +20,28 @@ public class Member {
     private Long memberId;
 
     @OneToMany(mappedBy = "member", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
-    private Set<Role> authorities = new HashSet<>();
+    private Set<MemberRole> roles = new HashSet<>();
 
     private String username;
     private String nickname;
     private String password;
+
+    @Builder
+    public Member(String username, String nickname, String password) {
+        this.username = username;
+        this.nickname = nickname;
+        this.password = password;
+    }
+
+    public void setRole(MemberRole memberRole) {
+        roles.add(memberRole);
+        memberRole.setMember(this);
+    }
+
+    public Set<RoleType> getAuthorities() {
+        return roles.stream()
+                .map(MemberRole::getRole)
+                .map(Role::getRoleType)
+                .collect(Collectors.toSet());
+    }
 }

--- a/src/main/java/com/mission/intern/domain/member/entity/MemberAuthorities.java
+++ b/src/main/java/com/mission/intern/domain/member/entity/MemberAuthorities.java
@@ -1,0 +1,27 @@
+package com.mission.intern.domain.member.entity;
+
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+
+@Getter
+@Entity(name = "members_authorities")
+@NoArgsConstructor
+@AllArgsConstructor
+public class MemberAuthorities {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long memberAuthoritiesId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "role_id")
+    private Role role;
+}

--- a/src/main/java/com/mission/intern/domain/member/entity/MemberRole.java
+++ b/src/main/java/com/mission/intern/domain/member/entity/MemberRole.java
@@ -1,9 +1,7 @@
 package com.mission.intern.domain.member.entity;
 
 
-import com.mission.intern.domain.member.vo.RoleType;
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;

--- a/src/main/java/com/mission/intern/domain/member/entity/MemberRole.java
+++ b/src/main/java/com/mission/intern/domain/member/entity/MemberRole.java
@@ -1,21 +1,22 @@
 package com.mission.intern.domain.member.entity;
 
 
+import com.mission.intern.domain.member.vo.RoleType;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 
 @Getter
-@Entity(name = "members_authorities")
+@Entity(name = "members_roles")
 @NoArgsConstructor
-@AllArgsConstructor
-public class MemberAuthorities {
+public class MemberRole {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long memberAuthoritiesId;
+    private Long memberRoleId;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
@@ -24,4 +25,13 @@ public class MemberAuthorities {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "role_id")
     private Role role;
+
+    @Builder
+    public MemberRole(Role role) {
+        this.role = role;
+    }
+
+    public void setMember(Member member) {
+        this.member = member;
+    }
 }

--- a/src/main/java/com/mission/intern/domain/member/entity/Role.java
+++ b/src/main/java/com/mission/intern/domain/member/entity/Role.java
@@ -3,13 +3,13 @@ package com.mission.intern.domain.member.entity;
 import com.mission.intern.domain.member.vo.RoleType;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @Entity(name = "roles")
 @NoArgsConstructor
-@AllArgsConstructor
 public class Role {
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -18,4 +18,9 @@ public class Role {
     @Enumerated(EnumType.STRING)
     @Column(nullable = false, unique = true)
     private RoleType roleType;
+
+    @Builder
+    public Role(RoleType roleType) {
+        this.roleType = roleType;
+    }
 }

--- a/src/main/java/com/mission/intern/domain/member/entity/Role.java
+++ b/src/main/java/com/mission/intern/domain/member/entity/Role.java
@@ -1,0 +1,21 @@
+package com.mission.intern.domain.member.entity;
+
+import com.mission.intern.domain.member.vo.RoleType;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity(name = "roles")
+@NoArgsConstructor
+@AllArgsConstructor
+public class Role {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long roleId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, unique = true)
+    private RoleType roleType;
+}

--- a/src/main/java/com/mission/intern/domain/member/entity/Role.java
+++ b/src/main/java/com/mission/intern/domain/member/entity/Role.java
@@ -2,7 +2,6 @@ package com.mission.intern.domain.member.entity;
 
 import com.mission.intern.domain.member.vo.RoleType;
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;

--- a/src/main/java/com/mission/intern/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/mission/intern/domain/member/repository/MemberRepository.java
@@ -1,0 +1,7 @@
+package com.mission.intern.domain.member.repository;
+
+import com.mission.intern.domain.member.entity.Member;
+
+public interface MemberRepository {
+    Member save(Member member);
+}

--- a/src/main/java/com/mission/intern/domain/member/repository/RoleRepository.java
+++ b/src/main/java/com/mission/intern/domain/member/repository/RoleRepository.java
@@ -1,0 +1,11 @@
+package com.mission.intern.domain.member.repository;
+
+import com.mission.intern.domain.member.entity.Role;
+import com.mission.intern.domain.member.vo.RoleType;
+
+import java.util.Optional;
+
+public interface RoleRepository {
+    Optional<Role> findByRoleType(RoleType roleType);
+
+}

--- a/src/main/java/com/mission/intern/domain/member/vo/RoleType.java
+++ b/src/main/java/com/mission/intern/domain/member/vo/RoleType.java
@@ -1,0 +1,5 @@
+package com.mission.intern.domain.member.vo;
+
+public enum RoleType {
+    ROLE_USER, ROLE_ADMIN
+}

--- a/src/main/java/com/mission/intern/infrastructure/member/MemberRepositoryImpl.java
+++ b/src/main/java/com/mission/intern/infrastructure/member/MemberRepositoryImpl.java
@@ -1,0 +1,19 @@
+package com.mission.intern.infrastructure.member;
+
+import com.mission.intern.domain.member.entity.Member;
+import com.mission.intern.domain.member.repository.MemberRepository;
+import com.mission.intern.infrastructure.member.hibernate.MemberJpaRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class MemberRepositoryImpl implements MemberRepository {
+
+    private final MemberJpaRepository jpaRepository;
+
+    @Override
+    public Member save(Member member) {
+        return jpaRepository.save(member);
+    }
+}

--- a/src/main/java/com/mission/intern/infrastructure/member/RoleRepositoryImpl.java
+++ b/src/main/java/com/mission/intern/infrastructure/member/RoleRepositoryImpl.java
@@ -1,0 +1,22 @@
+package com.mission.intern.infrastructure.member;
+
+import com.mission.intern.domain.member.entity.Role;
+import com.mission.intern.domain.member.repository.RoleRepository;
+import com.mission.intern.domain.member.vo.RoleType;
+import com.mission.intern.infrastructure.member.hibernate.RoleJpaRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class RoleRepositoryImpl implements RoleRepository {
+
+    private final RoleJpaRepository jpaRepository;
+
+    @Override
+    public Optional<Role> findByRoleType(RoleType roleType) {
+        return jpaRepository.findByRoleType(roleType);
+    }
+}

--- a/src/main/java/com/mission/intern/infrastructure/member/hibernate/MemberJpaRepository.java
+++ b/src/main/java/com/mission/intern/infrastructure/member/hibernate/MemberJpaRepository.java
@@ -1,0 +1,8 @@
+package com.mission.intern.infrastructure.member.hibernate;
+
+
+import com.mission.intern.domain.member.entity.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberJpaRepository extends JpaRepository<Member, Long> {
+}

--- a/src/main/java/com/mission/intern/infrastructure/member/hibernate/RoleJpaRepository.java
+++ b/src/main/java/com/mission/intern/infrastructure/member/hibernate/RoleJpaRepository.java
@@ -1,0 +1,12 @@
+package com.mission.intern.infrastructure.member.hibernate;
+
+import com.mission.intern.domain.member.entity.Role;
+import com.mission.intern.domain.member.vo.RoleType;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface RoleJpaRepository extends JpaRepository<Role, Long> {
+
+    Optional<Role> findByRoleType(RoleType roleType);
+}

--- a/src/main/java/com/mission/intern/presentation/MemberController.java
+++ b/src/main/java/com/mission/intern/presentation/MemberController.java
@@ -1,0 +1,25 @@
+package com.mission.intern.presentation;
+
+import com.mission.intern.application.member.MemberService;
+import com.mission.intern.presentation.member.dto.request.RegisterRequest;
+import com.mission.intern.presentation.member.dto.response.RegisteredMemberInfo;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/member")
+@RequiredArgsConstructor
+public class MemberController {
+
+    private final MemberService memberService;
+
+    @PostMapping("/register")
+    public ResponseEntity<RegisteredMemberInfo> register(@RequestBody RegisterRequest request) {
+        RegisteredMemberInfo response = memberService.register(request);
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/com/mission/intern/presentation/member/dto/request/RegisterRequest.java
+++ b/src/main/java/com/mission/intern/presentation/member/dto/request/RegisterRequest.java
@@ -1,0 +1,19 @@
+package com.mission.intern.presentation.member.dto.request;
+
+import com.mission.intern.domain.member.entity.Member;
+import com.mission.intern.domain.member.vo.RoleType;
+
+public record RegisterRequest(
+        String username,
+        String nickname,
+        String password,
+        RoleType role
+) {
+    public Member of() {
+        return Member.builder()
+                .username(username)
+                .nickname(nickname)
+                .password(password)
+                .build();
+    }
+}

--- a/src/main/java/com/mission/intern/presentation/member/dto/response/AuthorityResponse.java
+++ b/src/main/java/com/mission/intern/presentation/member/dto/response/AuthorityResponse.java
@@ -1,0 +1,6 @@
+package com.mission.intern.presentation.member.dto.response;
+
+public record AuthorityResponse(
+        String authorityName
+) {
+}

--- a/src/main/java/com/mission/intern/presentation/member/dto/response/RegisteredMemberInfo.java
+++ b/src/main/java/com/mission/intern/presentation/member/dto/response/RegisteredMemberInfo.java
@@ -1,0 +1,29 @@
+package com.mission.intern.presentation.member.dto.response;
+
+import com.mission.intern.domain.member.entity.Member;
+import com.mission.intern.domain.member.vo.RoleType;
+import lombok.Builder;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Builder
+public record RegisteredMemberInfo(
+        String username,
+        String nickname,
+        Set<AuthorityResponse> authorities
+) {
+
+    public static RegisteredMemberInfo from(Member member) {
+        Set<AuthorityResponse> authorities = member.getAuthorities().stream()
+                .map(RoleType::name)
+                .map(AuthorityResponse::new)
+                .collect(Collectors.toSet());
+
+        return RegisteredMemberInfo.builder()
+                .username(member.getUsername())
+                .nickname(member.getNickname())
+                .authorities(authorities)
+                .build();
+    }
+}


### PR DESCRIPTION
# 관련 이슈
- closes #1 

# 작업
- 과제에서 요구하는 요구사항 중 회원가입 시 반환되는 Response의 양식을 확인해봤다.

```java
{
	"username": "JIN HO",
	"nickname": "Mentos",
	"authorities": [
			{
					"authorityName": "ROLE_USER"
			}
	]		
}
```

Collection으로 묶인 `authorities` 속성을 보고 다음과 같은 요구사항이 아닐까 생각했다.

<aside>
🏁 “멤버는 다양한 권한(일반 멤버 또는 관리자)을 가질 수 있다.”

</aside>

일대다(`Member has Set<Role>`)의 형태로 가져가려고 했으나, 멤버에 권한이 있는 것이 찝찝하여 정규화를 통해 부분적 종속을 제거하기로 결정했다.

그렇게 작성한 ERD는 다대다의 연관관계를 중간 테이블로 묶은 형태가 되었다.

<img width="835" alt="image" src="https://github.com/user-attachments/assets/8cb9ab81-b220-401e-ad85-eec27931ce01">


참고로, JPA를 사용할 때 @ManyToMany를 그대로 사용하는 것은 많은 개발자들에게 거부감을 일으킨다.

중간 테이블을 JPA에서 만들고, 필수 속성(PK, FK 등) 외에 추가적인 속성을 임의로 넣을 수 없게 되기 때문이다.

내 상황에서는 `멤버의 권한을 일시적으로도 부여할 수 있다.` 라는 정책이 생겼을 때, MEMBER_ROLE 테이블에 `expired_date` 등을 넣어야 할 때가 있어도 이런 비즈니스 로직과 관련된 속성을 넣을 수 없다는 것이다.

물론, 지금 내 상황에서는 정규화의 목적이 더 크긴하지만, 아직 JPA를 쓰면서 다대다 관계를 풀어본 적이 없어서 경험을 쌓고자 이번 인턴 과제를 빌미로 한 번 해보려고 시도했다.

그렇게 다대다 관계를 `멤버(1) - 멤버권한(N) 양방향 관계` 설정, `멤버권한(N) - 권한(1) 단방향 관계` 설정을 통하여 풀어냈고, 가장 많이 사용될 멤버 엔티티에 `연관관계 편의 메서드`를 설정했다. 

이후 컨트롤러, 비즈니스 로직, 레포리토리를 작성하여 회원가입을 구현했다.

# 고민
- Member에서 getAuthorities()를 통해 멤버가 가진 권한을 돌려주는 것이 SRP 원칙에 맞는지 고민이다. 도메인 로직이라고 부를 수 있을까?
# 학습
- 클래스 선언부에 @Builder를 사용하지 않아야 할 이유를 알게 되었다.