### PR TITLE
Feat: Spring Security 설정

### DIFF
--- a/src/main/java/com/mission/intern/application/member/MemberService.java
+++ b/src/main/java/com/mission/intern/application/member/MemberService.java
@@ -10,6 +10,7 @@ import com.mission.intern.presentation.member.dto.request.RegisterRequest;
 import com.mission.intern.presentation.member.dto.response.RegisteredMemberInfo;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -18,6 +19,7 @@ public class MemberService {
 
     private final MemberRepository memberRepository;
     private final RoleRepository roleRepository;
+    private final PasswordEncoder passwordEncoder;
 
     @Transactional
     public RegisteredMemberInfo register(RegisterRequest request) {
@@ -25,6 +27,7 @@ public class MemberService {
         Role role = getRole(request.role());
         MemberRole memberRole = new MemberRole(role);
 
+        member.setPassword(passwordEncoder.encode(request.password()));
         member.setRole(memberRole);
 
         return RegisteredMemberInfo.from(member);

--- a/src/main/java/com/mission/intern/domain/member/entity/Member.java
+++ b/src/main/java/com/mission/intern/domain/member/entity/Member.java
@@ -38,6 +38,10 @@ public class Member {
         memberRole.setMember(this);
     }
 
+    public void setPassword(String password) {
+        this.password = password;
+    }
+
     public Set<RoleType> getAuthorities() {
         return roles.stream()
                 .map(MemberRole::getRole)

--- a/src/main/java/com/mission/intern/global/security/SecurityConfig.java
+++ b/src/main/java/com/mission/intern/global/security/SecurityConfig.java
@@ -1,0 +1,44 @@
+package com.mission.intern.global.security;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+    private final static String USER_API = "api/v1/member/";
+
+    @Bean
+    public WebSecurityCustomizer webSecurityCustomizer() {
+        return web -> web.ignoring().requestMatchers("/resources/**");
+    }
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(AbstractHttpConfigurer::disable)
+
+                .headers(headers -> headers.frameOptions(HeadersConfigurer.FrameOptionsConfig::disable))
+
+                .authorizeHttpRequests(authorize -> authorize
+                        .requestMatchers("/h2-console/**").permitAll()
+                        .requestMatchers(USER_API + "register", USER_API + "login").permitAll()
+                        .anyRequest().authenticated()
+                );
+
+        return http.build();
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/src/main/java/com/mission/intern/presentation/member/MemberController.java
+++ b/src/main/java/com/mission/intern/presentation/member/MemberController.java
@@ -1,4 +1,4 @@
-package com.mission.intern.presentation;
+package com.mission.intern.presentation.member;
 
 import com.mission.intern.application.member.MemberService;
 import com.mission.intern.presentation.member.dto.request.RegisterRequest;


### PR DESCRIPTION
# 관련 이슈
- closes #3 
# 작업
SecurityConfig 파일을 생성해서 Security를 활성화하는 어노테이션 @EnableWebSecurity를 추가한뒤, 다음과 같은 설정을 하였다.

- 리소스에 대한 접근은 무시한다.
- csrf를 비활성화 한다.
- h2-console 접속을 위한 frameOptions()를 비활성화 한다.
- h2-console, 회원가입, 로그인에 대해 접근 권한을 열어둔다.
- 그 외 접근은 인증된 사용자에게만 허용한다.
- 패스워드 암호화를 추가한다. (회원가입 시 암호화 적용을 위해)
  - 멤버 회원가입에 패스워드 암호화가 적용되게끔 변경하였다!

그리고 이 PR과는 크게 관련이 없지만, MemberController의 패키지 위치가 잘못 되어서 이를 이동시켰다.

# 고민
- 로그인 URI는 formLogin()를 사용하려고 했는데 성공시 리다이렉트 페이지, 실패 시 리다이렉트 페이지를 적용할 수 없어서 쉽게 포기했다. formLogin()을 제대로 활용하는 방법이 뭘까?

# 학습
- SecurityFilterChain에 대해서 더 깊게 학습해 볼 것