### PR TITLE
Feat: JWT / Filter 구현 / Spring Security 보완

### DIFF
--- a/src/main/java/com/mission/intern/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/mission/intern/domain/member/repository/MemberRepository.java
@@ -2,6 +2,9 @@ package com.mission.intern.domain.member.repository;
 
 import com.mission.intern.domain.member.entity.Member;
 
+import java.util.Optional;
+
 public interface MemberRepository {
     Member save(Member member);
+    Optional<Member> findByUsername(String username);
 }

--- a/src/main/java/com/mission/intern/global/filter/AuthenticateFilter.java
+++ b/src/main/java/com/mission/intern/global/filter/AuthenticateFilter.java
@@ -18,7 +18,7 @@ import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
-import java.util.List;
+import java.util.Set;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -34,7 +34,7 @@ public class AuthenticateFilter extends OncePerRequestFilter {
         if (jwtUtil.validateToken(accessToken)) {
             Claims claims = jwtUtil.getClaims(accessToken);
             String username = claims.getSubject();
-            List<SimpleGrantedAuthority> authorities = jwtUtil.getAuthorities(claims);
+            Set<SimpleGrantedAuthority> authorities = jwtUtil.getAuthorities(claims);
             UserDetails principal = userDetailService.loadUserByUsername(username);
             Authentication authentication = new UsernamePasswordAuthenticationToken(principal, "", authorities);
 

--- a/src/main/java/com/mission/intern/global/filter/AuthenticateFilter.java
+++ b/src/main/java/com/mission/intern/global/filter/AuthenticateFilter.java
@@ -1,0 +1,55 @@
+package com.mission.intern.global.filter;
+
+import com.mission.intern.global.jwt.JwtUtil;
+import com.mission.intern.global.security.CustomUserDetailService;
+import io.jsonwebtoken.Claims;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.List;
+
+@Slf4j
+@RequiredArgsConstructor
+public class AuthenticateFilter extends OncePerRequestFilter {
+
+    private final JwtUtil jwtUtil;
+    private final CustomUserDetailService userDetailService;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        String accessToken = resolveToken(request);
+
+        if (jwtUtil.validateToken(accessToken)) {
+            Claims claims = jwtUtil.getClaims(accessToken);
+            String username = claims.getSubject();
+            List<SimpleGrantedAuthority> authorities = jwtUtil.getAuthorities(claims);
+            UserDetails principal = userDetailService.loadUserByUsername(username);
+            Authentication authentication = new UsernamePasswordAuthenticationToken(principal, "", authorities);
+
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+        }
+
+        response.sendError(HttpServletResponse.SC_BAD_REQUEST);
+    }
+
+    private String resolveToken(HttpServletRequest request) {
+        String accessToken = request.getHeader(HttpHeaders.AUTHORIZATION);
+
+        if (accessToken != null && accessToken.startsWith("Bearer ")) {
+            return accessToken.substring(7);
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/mission/intern/global/jwt/JwtProperties.java
+++ b/src/main/java/com/mission/intern/global/jwt/JwtProperties.java
@@ -1,0 +1,12 @@
+package com.mission.intern.global.jwt;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "jwt")
+public record JwtProperties(
+        String issuer,
+        String secret,
+        Long accessTokenExpirationHour,
+        Long refreshTokenExpirationHour
+) {
+}

--- a/src/main/java/com/mission/intern/global/jwt/JwtUtil.java
+++ b/src/main/java/com/mission/intern/global/jwt/JwtUtil.java
@@ -18,7 +18,7 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.Arrays;
 import java.util.Date;
-import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 @Slf4j
@@ -43,10 +43,10 @@ public class JwtUtil implements InitializingBean {
         return TokenResponse.from(accessToken);
     }
 
-    public List<SimpleGrantedAuthority> getAuthorities(Claims claims) {
+    public Set<SimpleGrantedAuthority> getAuthorities(Claims claims) {
         return Arrays.stream(claims.get("auth").toString().split(","))
                 .map(SimpleGrantedAuthority::new)
-                .toList();
+                .collect(Collectors.toSet());
     }
 
     public boolean validateToken(String accessToken) {

--- a/src/main/java/com/mission/intern/global/jwt/JwtUtil.java
+++ b/src/main/java/com/mission/intern/global/jwt/JwtUtil.java
@@ -1,0 +1,105 @@
+package com.mission.intern.global.jwt;
+
+import com.mission.intern.presentation.member.dto.response.TokenResponse;
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.security.Keys;
+import io.jsonwebtoken.security.SecurityException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import java.security.Key;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JwtUtil implements InitializingBean {
+
+    private final JwtProperties jwtProperties;
+    private Key key;
+
+    @Override
+    public void afterPropertiesSet() throws Exception {
+        this.key = Keys.hmacShaKeyFor(jwtProperties.secret().getBytes());
+    }
+
+    public TokenResponse generateJwt(Authentication authentication) {
+        String accessToken = generateAccessToken(authentication);
+        String refreshToken = generateRefreshToken(authentication);
+
+        // TODO: refreshToken 저장
+
+        return TokenResponse.from(accessToken);
+    }
+
+    public List<SimpleGrantedAuthority> getAuthorities(Claims claims) {
+        return Arrays.stream(claims.get("auth").toString().split(","))
+                .map(SimpleGrantedAuthority::new)
+                .toList();
+    }
+
+    public boolean validateToken(String accessToken) {
+        try {
+            Jwts.parser().verifyWith((SecretKey) key).build().parseSignedClaims(accessToken);
+            return true;
+        } catch (MalformedJwtException | SecurityException e) {
+            log.info("토큰의 형식이 올바르지 않습니다");
+        } catch (ExpiredJwtException e) {
+            log.info("토큰이 만료되었습니다");
+        } catch (UnsupportedJwtException e) {
+            log.info("지원하지 않는 토큰입니다.");
+        } catch (IllegalArgumentException e) {
+            log.info("올바르지 않은 토큰 접근입니다.");
+        } catch (NullPointerException e) {
+            log.info("토큰이 존재하지 않습니다");
+        }
+        return false;
+    }
+
+    public Claims getClaims(String accessToken) {
+        try {
+            return Jwts.parser()
+                    .verifyWith((SecretKey) key)
+                    .build()
+                    .parseSignedClaims(accessToken)
+                    .getPayload();
+        } catch (ExpiredJwtException e) {
+            return e.getClaims();
+        }
+    }
+
+    private String generateAccessToken(Authentication authentication) {
+        String authorities = authentication.getAuthorities()
+                .stream().map(GrantedAuthority::getAuthority)
+                .collect(Collectors.joining(","));
+
+        Instant now = Instant.now();
+
+        return Jwts.builder()
+                .subject(authentication.getName())
+                .issuer(jwtProperties.issuer())
+                .expiration(Date.from(now.plus(Duration.ofHours(jwtProperties.accessTokenExpirationHour()))))
+                .signWith(key)
+                .claim("auth", authorities)
+                .compact();
+    }
+
+    private String generateRefreshToken(Authentication authentication) {
+        Instant now = Instant.now();
+        return Jwts.builder()
+                .expiration(Date.from(now.plus(Duration.ofHours(jwtProperties.refreshTokenExpirationHour()))))
+                .signWith(key)
+                .compact();
+    }
+}

--- a/src/main/java/com/mission/intern/global/property/PropertiesConfig.java
+++ b/src/main/java/com/mission/intern/global/property/PropertiesConfig.java
@@ -1,0 +1,10 @@
+package com.mission.intern.global.property;
+
+import com.mission.intern.global.jwt.JwtProperties;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableConfigurationProperties({JwtProperties.class})
+public class PropertiesConfig {
+}

--- a/src/main/java/com/mission/intern/global/security/CustomAccessDeniedHandler.java
+++ b/src/main/java/com/mission/intern/global/security/CustomAccessDeniedHandler.java
@@ -1,0 +1,18 @@
+package com.mission.intern.global.security;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+public class CustomAccessDeniedHandler implements AccessDeniedHandler {
+    @Override
+    public void handle(HttpServletRequest request, HttpServletResponse response, AccessDeniedException accessDeniedException) throws IOException, ServletException {
+        response.sendError(HttpServletResponse.SC_FORBIDDEN);
+    }
+}

--- a/src/main/java/com/mission/intern/global/security/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/com/mission/intern/global/security/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,18 @@
+package com.mission.intern.global.security;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException, ServletException {
+        response.sendError(HttpServletResponse.SC_UNAUTHORIZED);
+    }
+}

--- a/src/main/java/com/mission/intern/global/security/CustomUserDetailService.java
+++ b/src/main/java/com/mission/intern/global/security/CustomUserDetailService.java
@@ -1,0 +1,34 @@
+package com.mission.intern.global.security;
+
+import com.mission.intern.domain.member.entity.Member;
+import com.mission.intern.domain.member.entity.MemberRole;
+import com.mission.intern.domain.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class CustomUserDetailService implements UserDetailsService {
+
+    private final MemberRepository memberRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        Member member = memberRepository.findByUsername(username).orElseThrow(IllegalArgumentException::new);
+        Set<MemberRole> roles = member.getRoles();
+
+        Set<SimpleGrantedAuthority> authorities = roles.stream()
+                .map(memberRole -> new SimpleGrantedAuthority(memberRole.getRole().getRoleType().name()))
+                .collect(Collectors.toSet());
+
+        return new User(member.getUsername(), "", authorities);
+    }
+}

--- a/src/main/java/com/mission/intern/global/security/SecurityConfig.java
+++ b/src/main/java/com/mission/intern/global/security/SecurityConfig.java
@@ -1,5 +1,8 @@
 package com.mission.intern.global.security;
 
+import com.mission.intern.global.filter.AuthenticateFilter;
+import com.mission.intern.global.jwt.JwtUtil;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -10,11 +13,17 @@ import org.springframework.security.config.annotation.web.configurers.HeadersCon
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
 @EnableWebSecurity
+@RequiredArgsConstructor
 public class SecurityConfig {
     private final static String USER_API = "api/v1/member/";
+    private final JwtUtil jwtUtil;
+    private final CustomUserDetailService userDetailService;
+    private final CustomAccessDeniedHandler accessDeniedHandler;
+    private final CustomAuthenticationEntryPoint authenticationEntryPoint;
 
     @Bean
     public WebSecurityCustomizer webSecurityCustomizer() {
@@ -27,12 +36,17 @@ public class SecurityConfig {
                 .csrf(AbstractHttpConfigurer::disable)
 
                 .headers(headers -> headers.frameOptions(HeadersConfigurer.FrameOptionsConfig::disable))
-
                 .authorizeHttpRequests(authorize -> authorize
                         .requestMatchers("/h2-console/**").permitAll()
                         .requestMatchers(USER_API + "register", USER_API + "login").permitAll()
-                        .anyRequest().authenticated()
-                );
+                        .anyRequest().authenticated())
+
+                .addFilterBefore(new AuthenticateFilter(jwtUtil, userDetailService), UsernamePasswordAuthenticationFilter.class)
+
+                .exceptionHandling(handler -> {
+                    handler.accessDeniedHandler(accessDeniedHandler);
+                    handler.authenticationEntryPoint(authenticationEntryPoint);
+                });
 
         return http.build();
     }

--- a/src/main/java/com/mission/intern/infrastructure/member/MemberRepositoryImpl.java
+++ b/src/main/java/com/mission/intern/infrastructure/member/MemberRepositoryImpl.java
@@ -6,6 +6,8 @@ import com.mission.intern.infrastructure.member.hibernate.MemberJpaRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 @RequiredArgsConstructor
 public class MemberRepositoryImpl implements MemberRepository {
@@ -15,5 +17,10 @@ public class MemberRepositoryImpl implements MemberRepository {
     @Override
     public Member save(Member member) {
         return jpaRepository.save(member);
+    }
+
+    @Override
+    public Optional<Member> findByUsername(String username) {
+        return jpaRepository.findByUsername(username);
     }
 }

--- a/src/main/java/com/mission/intern/infrastructure/member/hibernate/MemberJpaRepository.java
+++ b/src/main/java/com/mission/intern/infrastructure/member/hibernate/MemberJpaRepository.java
@@ -4,5 +4,8 @@ package com.mission.intern.infrastructure.member.hibernate;
 import com.mission.intern.domain.member.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface MemberJpaRepository extends JpaRepository<Member, Long> {
+    Optional<Member> findByUsername(String username);
 }

--- a/src/main/java/com/mission/intern/presentation/member/dto/response/TokenResponse.java
+++ b/src/main/java/com/mission/intern/presentation/member/dto/response/TokenResponse.java
@@ -1,0 +1,16 @@
+package com.mission.intern.presentation.member.dto.response;
+
+import lombok.Builder;
+
+@Builder
+public record TokenResponse(
+        String accessToken
+) {
+
+    public static TokenResponse from(String accessToken) {
+        return TokenResponse.builder()
+                .accessToken(accessToken)
+                .build();
+    }
+
+}


### PR DESCRIPTION
# 관련 이슈
- closes #5
# 작업
- Security Filter Chain에서 인증이 필요한 경우, 인증을 구현 할 Filter를 추가했다.
- JWT를 발급 / 검증 / 정보 검색에 활용할 수 있는 JwtUtil 클래스를 만들었다.
  - JWT에 필요한 속성을 JwtProperties를 통해 관리하게 했다.
- 인증 / 인가 실패 처리를 위한 인터페이스(AccessDeniedHandler, AuthenticationHandler)를 구현했다.
# 고민
- 리프레시 토큰을 Redis 같은 NoSQL을 사용할지 테이블을 새로 하나 생성할 지 고민 중이다. 오버 엔지니어링 안되게 후자 쪽에 더 힘이 실리긴 하는 것 같다.
# 학습
- Spring Security 아키텍처를 통해 청사진을 보고 인증/인가에 어떤 인터페이스를 사용해야 되는지 알게 되었고, 인증/인가 실패시 추가 기능이 필요하다면 추후 적용할 생각이다.