### PR TITLE
Feat: 로그인 기능 구현

### DIFF
--- a/src/main/java/com/mission/intern/application/member/MemberService.java
+++ b/src/main/java/com/mission/intern/application/member/MemberService.java
@@ -1,17 +1,27 @@
 package com.mission.intern.application.member;
 
+import com.mission.intern.domain.member.entity.Member;
 import com.mission.intern.domain.member.entity.MemberRole;
 import com.mission.intern.domain.member.entity.Role;
 import com.mission.intern.domain.member.repository.MemberRepository;
-import com.mission.intern.domain.member.entity.Member;
 import com.mission.intern.domain.member.repository.RoleRepository;
 import com.mission.intern.domain.member.vo.RoleType;
+import com.mission.intern.global.jwt.JwtUtil;
+import com.mission.intern.presentation.member.dto.request.LoginRequest;
 import com.mission.intern.presentation.member.dto.request.RegisterRequest;
 import com.mission.intern.presentation.member.dto.response.RegisteredMemberInfo;
+import com.mission.intern.presentation.member.dto.response.TokenResponse;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+
+import java.util.Set;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -20,6 +30,8 @@ public class MemberService {
     private final MemberRepository memberRepository;
     private final RoleRepository roleRepository;
     private final PasswordEncoder passwordEncoder;
+    private final AuthenticationManagerBuilder authenticationManagerBuilder;
+    private final JwtUtil jwtUtil;
 
     @Transactional
     public RegisteredMemberInfo register(RegisterRequest request) {
@@ -31,6 +43,28 @@ public class MemberService {
         member.setRole(memberRole);
 
         return RegisteredMemberInfo.from(member);
+    }
+
+    public TokenResponse login(LoginRequest request) {
+        Member member = getMemberByUsername(request.username());
+
+        if (!passwordEncoder.matches(request.password(), member.getPassword())) {
+            throw new IllegalArgumentException("비밀번호가 일치하지 않습니다.");
+        }
+
+        Set<SimpleGrantedAuthority> authorities = member.getAuthorities().stream()
+                .map(roleType -> new SimpleGrantedAuthority(roleType.name()))
+                .collect(Collectors.toSet());
+
+        UsernamePasswordAuthenticationToken authenticationToken = new UsernamePasswordAuthenticationToken(member.getMemberId(), member.getPassword(), authorities);
+        Authentication authentication = authenticationManagerBuilder.getObject().authenticate(authenticationToken);
+        TokenResponse response = jwtUtil.generateJwt(authentication);
+
+        return response;
+    }
+
+    private Member getMemberByUsername(String username) {
+        return memberRepository.findByUsername(username).orElseThrow(IllegalArgumentException::new);
     }
 
     private Role getRole(RoleType roleType) {

--- a/src/main/java/com/mission/intern/presentation/member/MemberController.java
+++ b/src/main/java/com/mission/intern/presentation/member/MemberController.java
@@ -1,8 +1,10 @@
 package com.mission.intern.presentation.member;
 
 import com.mission.intern.application.member.MemberService;
+import com.mission.intern.presentation.member.dto.request.LoginRequest;
 import com.mission.intern.presentation.member.dto.request.RegisterRequest;
 import com.mission.intern.presentation.member.dto.response.RegisteredMemberInfo;
+import com.mission.intern.presentation.member.dto.response.TokenResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -21,5 +23,11 @@ public class MemberController {
     public ResponseEntity<RegisteredMemberInfo> register(@RequestBody RegisterRequest request) {
         RegisteredMemberInfo response = memberService.register(request);
         return ResponseEntity.ok(response);
+    }
+
+    @PostMapping("/login")
+    public ResponseEntity<TokenResponse> login(@RequestBody LoginRequest request) {
+        TokenResponse response = memberService.login(request);
+        return ResponseEntity.accepted().body(response);
     }
 }

--- a/src/main/java/com/mission/intern/presentation/member/dto/request/LoginRequest.java
+++ b/src/main/java/com/mission/intern/presentation/member/dto/request/LoginRequest.java
@@ -1,0 +1,7 @@
+package com.mission.intern.presentation.member.dto.request;
+
+public record LoginRequest(
+        String username,
+        String password
+) {
+}


### PR DESCRIPTION
# 관련 이슈
- closes #7 
# 작업
- 로그인 기능을 구현했다.
# 고민
- 엑세스 토큰과 리프레시 토큰 둘 다 저장할지, 엑세스 토큰은 클라이언트가 들게하고, 리프레시 토큰만 저장하여 엑세스 토큰 만료시 리프레시 토큰을 꺼내 검증할지 검증 방법에 대해서 고민 중이다. 
# 학습
- AuthenticationManagerBuilder에 대해서 알게 됐고 이를 비즈니스 로직에 적용해보았다.
